### PR TITLE
Remove kotlin-kapt plugin and auto-service

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -11,12 +11,15 @@ plugins {
     alias(libs.plugins.buildconfig) apply false
     alias(libs.plugins.dokka)
     id(libs.plugins.kotlin.jvm.get().pluginId)
-    id(libs.plugins.kotlin.kapt.get().pluginId)
 }
 
 allprojects {
     apply {
         plugin("kotlin")
+
+        tasks.withType<org.jetbrains.kotlin.gradle.dsl.KotlinCompile<*>> {
+            kotlinOptions.freeCompilerArgs += "-opt-in=kotlin.RequiresOptIn"
+        }
     }
 
     tasks.withType<KotlinJvmCompile> {

--- a/gradle-plugin/build.gradle.kts
+++ b/gradle-plugin/build.gradle.kts
@@ -4,7 +4,6 @@ group = rootProject.group
 version = rootProject.version
 
 plugins {
-    kotlin("kapt")
     `kotlin-dsl`
     alias(libs.plugins.kotlin.plugin.serialization)
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -7,7 +7,6 @@
 # Also, you should change the version in two places in the build.gradle.kts file in the example project
 kotlin = "1.7.0"
 
-auto-service = "1.0.1"
 buildconfig = "3.0.3"
 detekt = "1.20.0"
 dokka = "1.6.21"
@@ -22,8 +21,6 @@ tomlj = "1.0.0"
 zip4j = "2.10.0"
 
 [libraries]
-auto-service = { module = "com.google.auto.service:auto-service", version.ref = "auto-service" }
-auto-service-annotations = { module = "com.google.auto.service:auto-service-annotations", version.ref = "auto-service" }
 detekt-gradle-plugin = { module = "io.gitlab.arturbosch.detekt:detekt-gradle-plugin", version.ref = "detekt" }
 diktat-gradle-plugin = { module = "org.cqfn.diktat:diktat-gradle-plugin", version.ref = "diktat" }
 junit-jupiter-api = { module = "org.junit.jupiter:junit-jupiter-api", version.ref = "junit-jupiter" }
@@ -41,6 +38,5 @@ zip4j = { module = "net.lingala.zip4j:zip4j", version.ref = "zip4j" }
 buildconfig = { id = "com.github.gmazzo.buildconfig", version.ref = "buildconfig" }
 dokka = { id = "org.jetbrains.dokka", version.ref = "dokka" }
 kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
-kotlin-kapt = { id = "org.jetbrains.kotlin.kapt", version.ref = "kotlin" }
 kotlin-plugin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
 kosogor = { id = "tanvd.kosogor", version.ref = "kosogor" }

--- a/reflekt-dsl/build.gradle.kts
+++ b/reflekt-dsl/build.gradle.kts
@@ -9,7 +9,3 @@ dependencies {
 }
 
 publishJar {}
-
-tasks.withType<KotlinCompile<*>> {
-    kotlinOptions.freeCompilerArgs += "-opt-in=kotlin.RequiresOptIn"
-}

--- a/reflekt-plugin/build.gradle.kts
+++ b/reflekt-plugin/build.gradle.kts
@@ -5,7 +5,6 @@ version = rootProject.version
 
 plugins {
     alias(libs.plugins.kotlin.plugin.serialization)
-    id(libs.plugins.kotlin.kapt.get().pluginId)
 }
 
 dependencies {
@@ -13,9 +12,6 @@ dependencies {
     implementation(kotlin("scripting-common"))
     implementation(kotlin("scripting-jvm"))
     implementation(kotlin("scripting-jvm-host"))
-
-    implementation(libs.auto.service.annotations)
-    kapt(libs.auto.service)
 
     implementation(project(":reflekt-core"))
     implementation(project(":reflekt-dsl"))
@@ -52,10 +48,6 @@ tasks.create("analysis", Test::class.java) {
     testLogging {
         events("passed", "skipped", "failed")
     }
-}
-
-tasks.withType<org.jetbrains.kotlin.gradle.dsl.KotlinCompile<*>> {
-    kotlinOptions.freeCompilerArgs += "-opt-in=kotlin.RequiresOptIn"
 }
 
 tasks.processTestResources.configure {

--- a/reflekt-plugin/src/main/kotlin/org/jetbrains/reflekt/plugin/ReflektCommandLineProcessor.kt
+++ b/reflekt-plugin/src/main/kotlin/org/jetbrains/reflekt/plugin/ReflektCommandLineProcessor.kt
@@ -1,6 +1,5 @@
 package org.jetbrains.reflekt.plugin
 
-import com.google.auto.service.AutoService
 import org.jetbrains.kotlin.compiler.plugin.*
 import org.jetbrains.kotlin.config.CompilerConfiguration
 import org.jetbrains.kotlin.config.CompilerConfigurationKey
@@ -23,7 +22,6 @@ import java.io.File
  *  Should match up with the options returned from the ReflektSubPlugin.applyToCompilation in the gradle-plugin module.
  *  Should also have matching 'when'-branches for each option in the [processOption] function
  */
-@AutoService(CommandLineProcessor::class)
 class ReflektCommandLineProcessor : CommandLineProcessor {
     override val pluginId: String = PLUGIN_ID
     override val pluginOptions: Collection<CliOption> =

--- a/reflekt-plugin/src/main/kotlin/org/jetbrains/reflekt/plugin/ReflektComponentRegistrar.kt
+++ b/reflekt-plugin/src/main/kotlin/org/jetbrains/reflekt/plugin/ReflektComponentRegistrar.kt
@@ -2,7 +2,6 @@
 
 package org.jetbrains.reflekt.plugin
 
-import com.google.auto.service.AutoService
 import org.jetbrains.kotlin.backend.common.extensions.IrGenerationExtension
 import org.jetbrains.kotlin.com.intellij.mock.MockProject
 import org.jetbrains.kotlin.compiler.plugin.ComponentRegistrar
@@ -23,8 +22,8 @@ import java.io.File
 /**
  * Registers the plugin and applies it to the project.
  * We have two main cases to interact with Reflekt:
- *  a) the project case
- *  b) the library case
+ *  a) the project case,
+ *  b) the library case.
  *
  * The project case means that we search for Reflekt and SmartReflekt queries only in the current project,
  *  and replace their IR.
@@ -37,7 +36,6 @@ import java.io.File
  *
  * @property isTestConfiguration indicates if the plugin is used in tests
  */
-@AutoService(ComponentRegistrar::class)
 @Suppress("TOO_LONG_FUNCTION")
 class ReflektComponentRegistrar(private val isTestConfiguration: Boolean = false) : ComponentRegistrar {
     /**

--- a/reflekt-plugin/src/main/resources/META-INF/services/org.jetbrains.kotlin.compiler.plugin.CommandLineProcessor
+++ b/reflekt-plugin/src/main/resources/META-INF/services/org.jetbrains.kotlin.compiler.plugin.CommandLineProcessor
@@ -1,0 +1,1 @@
+org.jetbrains.reflekt.plugin.ReflektCommandLineProcessor

--- a/reflekt-plugin/src/main/resources/META-INF/services/org.jetbrains.kotlin.compiler.plugin.ComponentRegistrar
+++ b/reflekt-plugin/src/main/resources/META-INF/services/org.jetbrains.kotlin.compiler.plugin.ComponentRegistrar
@@ -1,0 +1,1 @@
+org.jetbrains.reflekt.plugin.ReflektComponentRegistrar


### PR DESCRIPTION
Remove kotlin-kapt plugin and auto-service annotation processor to speed up compilation of the compiler plugin and simplify the build code.